### PR TITLE
Fix/allow markdown styles to be displayed properly in model description in swagger ui

### DIFF
--- a/src/core/components/object-model.jsx
+++ b/src/core/components/object-model.jsx
@@ -79,8 +79,8 @@ export default class ObjectModel extends Component {
             {
               <table className="model"><tbody>
               {
-                !description ? null : <tr style={{ color: "#666", fontStyle: "italic" }}>
-                    <td>description:</td>
+                !description ? null : <tr style={{ color: "#666", fontWeight: "normal" }}>
+                    <td style={{ fontWeight: "bold" }}>description:</td>
                     <td>
                       <Markdown source={ description } />
                     </td>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Adjustments made to allow markdown styling to be displayed properly in model description field:
- Replaced italic in-line style with font-weight: normal to properly allow markdown styles for object models.
- Left Bold styling for description description key.


### Motivation and Context
In Swagger-UI, Models can have a description field, which can be styled using Markdown. Currently though, this is overridden by italic bold style when model description is actually displayed. 
Motivation for this change is the fact that, since Markdown style is allowed, the choices of styling user makes should be reflected in model description thats is displayed in Swagger-ui



### How Has This Been Tested?
This change has been tested using local development environment.



### Screenshots (if appropriate):
#### Model description display before this change
![image](https://user-images.githubusercontent.com/29974500/57126354-9f770980-6d84-11e9-92ee-8d114d14c79e.png)

#### Model description display after this change
![image](https://user-images.githubusercontent.com/29974500/57126426-d8af7980-6d84-11e9-96e1-150e85f37ec6.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
